### PR TITLE
return undefined values

### DIFF
--- a/index.tests.ts
+++ b/index.tests.ts
@@ -22,6 +22,14 @@ describe('Cookie Store', () => {
       const result = await window.cookieStore.get(foo);
       expect(result).to.deep.equal({ name: foo, value: bar });
     });
+    
+    it('returns undefined when no cookie is found', async () => {
+      const foo = 'foo';
+      const bar = 'bar';
+      document.cookie = `${foo}=${bar}`;
+      const result = await window.cookieStore.get(bar);
+      expect(result).to.deep.equal(undefined);
+    });
   });
   describe('getAll', () => {
     it('returns an array with all cookies if no name is provided', async () => {
@@ -43,6 +51,15 @@ describe('Cookie Store', () => {
       document.cookie = `${foo}=${bar}; ${bar}=${baz}`;
       const result = await window.cookieStore.getAll(bar);
       expect(result).to.deep.equal([{ name: bar, value: baz }]);
+    });
+    
+    it('returns an empty when no matching cookies are found', async () => {
+      const foo = 'foo';
+      const bar = 'bar';
+      const baz = 'baz';
+      document.cookie = `${foo}=${bar}; ${bar}=${baz}`;
+      const result = await window.cookieStore.getAll(baz);
+      expect(result).to.deep.equal([]);
     });
   });
   describe('set', () => {

--- a/index.ts
+++ b/index.ts
@@ -249,7 +249,7 @@ const CookieStore = {
    */
   async get(
     options?: CookieStoreGetOptions['name'] | CookieStoreGetOptions
-  ): Promise<Cookie> {
+  ): Promise<Cookie | undefined> {
     const { name } = sanitizeOptions(options);
     return parse(document.cookie).find((cookie) => cookie.name === name);
   },
@@ -282,7 +282,7 @@ const CookieStore = {
     const { name } = sanitizeOptions(options);
     if (name) {
       const cookie = await this.get(name);
-      return [cookie];
+      return cookie ? [cookie] : [];
     }
     return parse(document.cookie);
   },


### PR DESCRIPTION
This PR changes the `get` types to return undefined, as per the spec. Calling `await cookieStore.get('does_not_exist')` will return undefined.

Similarly this changes `getAll` to return `[]` instead of `[undefined]` for the case of `await cookieStore.getAll('does_not_exist')`