### PR TITLE
Allow passing options to set

### DIFF
--- a/index.tests.ts
+++ b/index.tests.ts
@@ -48,7 +48,12 @@ describe('Cookie Store', () => {
   describe('set', () => {
     it('updates document.cookie with supplied value', async () => {
       await window.cookieStore.set('foo', 'bar');
-      expect(document.cookie).to.equal('foo=bar');
+      expect(document.cookie).to.equal('foo=bar; Path=/; SameSite=Strict');
+    });
+    it('updates document.cookie based on supplied opts', async () => {
+      const expires = new Date()
+      await window.cookieStore.set({name: 'foo', value: 'bar', expires: +expires});
+      expect(document.cookie).to.equal(`foo=bar; Path=/; Expires=${expires.toUTCString()}; SameSite=Strict`);
     });
   });
   describe('delete', () => {


### PR DESCRIPTION
This alters `set` to allow passing in additional options such as `expires` as per the spec.

`CookieInit` is cribbed right from the spec (https://wicg.github.io/cookie-store/#ref-for-dictdef-cookieinit) and `set` has been altered to accept it.

This is also makes a potentially breaking change, in that (per spec) `set` will always default `path` to `/` and `samesite` to `strict`.