### PR TITLE
Run Web Platform Tests against the polyfill.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -256,7 +256,11 @@ const CookieStore = {
     }
     const { name, url } = sanitizeOptions<CookieStoreGetOptions>(options);
     if (url) {
-      if (url !== window.location.pathname && url !== window.location.href) {
+      const parsedURL = new URL(url, window.location.origin);
+      if (
+        window.location.href !== parsedURL.href ||
+        window.location.origin !== parsedURL.origin
+      ) {
         throw new TypeError('URL must match the document URL');
       }
       return parse(document.cookie)[0];

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,13 @@ const CookieStore = {
     if (!options || !Object.keys(options).length) {
       throw new TypeError('CookieStoreGetOptions must not be empty');
     }
-    const { name } = sanitizeOptions<CookieStoreGetOptions>(options);
+    const { name, url } = sanitizeOptions<CookieStoreGetOptions>(options);
+    if (url) {
+      if (url !== window.location.pathname && url !== window.location.href) {
+        throw new TypeError('URL must match the document URL');
+      }
+      return parse(document.cookie)[0];
+    }
     return parse(document.cookie).find((cookie) => cookie.name === name);
   },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,6 +256,9 @@ const CookieStore = {
   async get(
     options?: CookieStoreGetOptions['name'] | CookieStoreGetOptions
   ): Promise<Cookie | undefined> {
+    if (!options || !Object.keys(options).length) {
+      throw new TypeError('CookieStoreGetOptions must not be empty');
+    }
     const { name } = sanitizeOptions(options);
     return parse(document.cookie).find((cookie) => cookie.name === name);
   },

--- a/test/karma.conf.cjs
+++ b/test/karma.conf.cjs
@@ -1,8 +1,14 @@
 module.exports = function (config) {
   config.set({
     files: [
+      // Include the compiled library
       { pattern: '../dist/index.js', type: 'module' },
-      { pattern: './*.tests.js', type: 'module' }
+      // Set up test environment to be able to run WPT tests
+      { pattern: './wpt-setup/*.js', type: 'module' },
+      // Our tests
+      { pattern: './index.tests.js', type: 'module' },
+      // Web Platform Tests
+      { pattern: './wpt/*.js', type: 'module' }
     ],
     plugins: ['karma-*'],
     reporters: ['progress'],

--- a/test/wpt-setup/harness.js
+++ b/test/wpt-setup/harness.js
@@ -1,0 +1,33 @@
+/* global assert */
+
+window.promise_test = async (fn, name) => {
+  const cleanups = [];
+  const testCase = {
+    name,
+    add_cleanup(fn) {
+      cleanups.push(fn);
+    },
+  };
+  it(name, async () => {
+    await fn(testCase);
+    for (const cleanup of cleanups) {
+      cleanup();
+    }
+  });
+};
+
+window.promise_rejects_js = async (testCase, expectedError, promise) => {
+  try {
+    await promise;
+  } catch (error) {
+    if (error.name !== expectedError.name) {
+      assert.fail(
+        `${testCase.name}: Promise rejected with ${error.name}, expected ${expectedError.name}`
+      );
+    }
+    return;
+  }
+  assert.fail(`${testCase.name}: Promise didn't reject when it should have.`);
+};
+
+window.assert_equals = (one, two) => assert.equal(one, two);

--- a/test/wpt-setup/harness.js
+++ b/test/wpt-setup/harness.js
@@ -30,4 +30,4 @@ window.promise_rejects_js = async (testCase, expectedError, promise) => {
   assert.fail(`${testCase.name}: Promise didn't reject when it should have.`);
 };
 
-window.assert_equals = (one, two) => assert.equal(one, two);
+window.assert_equals = assert.equal;

--- a/test/wpt-setup/serviceworker_cookieStore_cross_origin.js
+++ b/test/wpt-setup/serviceworker_cookieStore_cross_origin.js
@@ -1,0 +1,13 @@
+self.GLOBAL = {
+  isWindow: () => false,
+  isWorker: () => false,
+};
+
+self.addEventListener('message', async event => {
+  if (event.data.op === 'get-cookies') {
+    const workerCookies = await cookieStore.getAll();
+    event.ports[0].postMessage({ workerCookies }, {
+        domain: event.origin,
+    });
+  }
+});

--- a/test/wpt/cookieStore_get_arguments.tentative.https.any.js
+++ b/test/wpt/cookieStore_get_arguments.tentative.https.any.js
@@ -1,0 +1,107 @@
+// META: title=Cookie Store API: cookieStore.get() arguments
+// META: global=window,serviceworker
+
+'use strict';
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.get());
+}, 'cookieStore.get with no arguments returns TypeError');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.get({}));
+}, 'cookieStore.get with empty options returns TypeError');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.get with positional name');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  const cookie = await cookieStore.get({ name: 'cookie-name' });
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.get with name in options');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  const cookie = await cookieStore.get('cookie-name', {
+    name: 'wrong-cookie-name',
+  });
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.get with name in both positional arguments and options');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  let target_url = self.location.href;
+  if (self.GLOBAL.isWorker()) {
+    target_url = target_url + '/path/within/scope';
+  }
+
+  const cookie = await cookieStore.get({ url: target_url });
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.get with absolute url in options');
+
+promise_test(async (testCase) => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  let target_path = self.location.pathname;
+  if (self.GLOBAL.isWorker()) {
+    target_path = target_path + '/path/within/scope';
+  }
+
+  const cookie = await cookieStore.get({ url: target_path });
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.get with relative url in options');
+
+promise_test(async (testCase) => {
+  const invalid_url = `${self.location.protocol}//${self.location.host}/different/path`;
+  await promise_rejects_js(
+    testCase,
+    TypeError,
+    cookieStore.get({ url: invalid_url })
+  );
+}, 'cookieStore.get with invalid url path in options');
+
+promise_test(async (testCase) => {
+  const invalid_url = `${self.location.protocol}//www.example.com${self.location.pathname}`;
+  await promise_rejects_js(
+    testCase,
+    TypeError,
+    cookieStore.get({ url: invalid_url })
+  );
+}, 'cookieStore.get with invalid url host in options');


### PR DESCRIPTION
This PR implements a test harness set up so that we are able to run [Web Platform Tests](https://github.com/web-platform-tests/wpt) against the polyfill. These tests are a good indicator of if the polyfill is fulfilling the spec since browser vendors use these tests to make sure that their implementations are matching the spec and each others implementation.

This change just pulls in a single test suite but I'll be building up a framework so that we can pull in all the cookie store tests and vendor them into the repo. The single test suite that this PR pulls in is [`wpt/cookie-store/cookieStore_get_arguments.tentative.https.any.html`](https://github.com/web-platform-tests/wpt/blob/master/cookie-store/cookieStore_get_arguments.tentative.https.any.js).

I had to make some modifications since the tests didn't run green from the beginning but I believe my changes align us closer to the spec.

cc/ @keithamus 