### PR TITLE
Fix test errors due to missing hosts file entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install cookie-store@next
 
 ```js
 // import polyfill and declare types
-import {cookieStore} from 'cookie-store';
+import { cookieStore } from 'cookie-store';
 
 // set a cookie
 await cookieStore.set('forgive', 'me');
@@ -37,3 +37,15 @@ console.log(cookies); // [{ name: 'forgive', value: 'me' }, { name: 'forget', va
 // delete a cookie
 await cookieStore.delete('forget');
 ```
+
+## Development
+
+### Tests
+
+Before running tests, you'll need to add the following entry to your `/etc/hosts` file on your machine:
+
+```
+127.0.0.1    foo.bar.localhost
+```
+
+Then run `npm test`


### PR DESCRIPTION
This fixes test errors that were present when running `npm run test:ts`. The errors were preventing creation of new preleases via release-it, since tests must be run and must pass before a prerelease can be generated and published. 

Adding a missing entry to the `/etc/hosts` file was required to get it working. Please feel free to let me know if there's anything that needs clarification. :rocket: 