### PR TITLE
Fix Chrome handling of ServiceWorker method check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -379,7 +379,7 @@ class CookieStoreManager {
   }
 }
 
-if (!ServiceWorkerRegistration.prototype.cookies) {
+if (!('cookies' in ServiceWorkerRegistration.prototype)) {
   Object.defineProperty(ServiceWorkerRegistration.prototype, 'cookies', {
     configurable: true,
     enumerable: true,


### PR DESCRIPTION
This is a fix for the issue covered in https://github.com/markcellus/cookie-store/issues/169

Chrome throws an illegal invocation exception if you call or introspect `ServiceWorkerRegistration.prototype.cookies` directly.

Edit: I've published my fork to https://www.npmjs.com/package/@kulor/cookie-store whilst waiting for this to be merged.