### PR TITLE
fix: ponyfill instance type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -404,5 +404,6 @@ declare global {
   }
 }
 
-const cookieStore = Object.create(CookieStore.prototype);
+const cookieStore = Object.create(CookieStore.prototype) as CookieStore;
+
 export { cookieStore, CookieStore, CookieChangeEvent };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "esnext",
     "strict": true,
     "noImplicitThis": true,
+    "noImplicitAny": true,
     "alwaysStrict": true,
     "esModuleInterop": true,
     "declaration": true,


### PR DESCRIPTION
@markcellus `Object.create()` in TypeScript has an `any` return type

![image](https://user-images.githubusercontent.com/19969570/206872967-e312facf-4e2a-46ff-8cae-f7aae30c27e8.png)
