### PR TITLE
Fix ServiceWorkerRegistration is not defined (#173)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -379,7 +379,10 @@ class CookieStoreManager {
   }
 }
 
-if (typeof ServiceWorkerRegistration !== 'undefined' && !('cookies' in ServiceWorkerRegistration.prototype)) {
+if (
+  typeof ServiceWorkerRegistration !== 'undefined' &&
+  !('cookies' in ServiceWorkerRegistration.prototype)
+) {
   Object.defineProperty(ServiceWorkerRegistration.prototype, 'cookies', {
     configurable: true,
     enumerable: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -379,7 +379,7 @@ class CookieStoreManager {
   }
 }
 
-if (!('cookies' in ServiceWorkerRegistration.prototype)) {
+if (typeof ServiceWorkerRegistration !== 'undefined' && !('cookies' in ServiceWorkerRegistration.prototype)) {
   Object.defineProperty(ServiceWorkerRegistration.prototype, 'cookies', {
     configurable: true,
     enumerable: true,


### PR DESCRIPTION
Adds an additional check for `ServiceWorkerRegistration` being defined before trying to access it, allowing the module to be imported in non-browser environments or browsers that don't define `ServiceWorkerRegistration`.

Fixes #173 